### PR TITLE
Add compatibility patch for Typhon

### DIFF
--- a/AlienMeatTest.csproj
+++ b/AlienMeatTest.csproj
@@ -71,6 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Compatibility\Compatibility_AnimalLogic.cs" />
+    <Compile Include="Compatibility\Compatibility_Typhon.cs" />
     <Compile Include="Compatibility\Compatibility_ARimworldOfMagic.cs" />
     <Compile Include="Compatibility\Compatibility.cs" />
     <Compile Include="Compatibility\CompatibilityDatabase.cs" />

--- a/Compatibility/Compatibility_Typhon.cs
+++ b/Compatibility/Compatibility_Typhon.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq;
+using Verse;
+
+namespace AlienMeatTest.Compatibility
+{
+    public class Compatibility_Typhon : Compatibility
+    {
+        protected override string PackageID => "caaz.typhon";
+        public override bool IsPreOptimization => true;
+        public override void DoPatch()
+        {
+            if (!DetectMod()) return;
+            MeatLogger.Debug("Typhon Detected!");
+            string typhonOrgan = "TyphonOrgan";
+            var typhonRaces = DefDatabase<ThingDef>.AllDefs.Where(x => x.race?.meatDef?.defName == typhonOrgan).ToList();
+            foreach (var i in typhonRaces)
+            {
+                MeatOptimization.WhiteListRace.Add(i.defName);
+            }
+            MeatOptimization.WhiteListMeat.Add("TyphonOrgan");
+        }
+    }
+}


### PR DESCRIPTION
Not sure how to test this easily on my end, looks like this is explicitly just the C# so I might not be able to build this to test.

So I just took a quick glance at how things work here and it looks like there's a whitelist for races and meat defs. The typhon mod requires the custom meat def `TyphonOrgan` available for certain recipes. 

Closes https://github.com/Caaz/rimworld-typhon/issues/82 on my end.