### PR TITLE
DND Menagerie Compatibility Patch

### DIFF
--- a/Compatibility/Compatibility_MoolohsDndMenagerie.cs
+++ b/Compatibility/Compatibility_MoolohsDndMenagerie.cs
@@ -18,11 +18,8 @@ namespace AlienMeatTest.Compatibility
             if (!DetectMod()) return;
             MeatLogger.Debug("Mooloh's DND Menagerie!");
 
-            MeatOptimization.WhiteListRace.Add("DND_GolemSteel");
-            MeatOptimization.WhiteListRace.Add("DND_GolemStone");
-            MeatOptimization.WhiteListRace.Add("DND_AnimatedToolCabinet"); 
-            MeatOptimization.WhiteListRace.Add("DND_AnimatedDiningChair");
-            MeatOptimization.WhiteListRace.Add("DND_AnimatedStool");
+            MeatOptimization.WhiteListMeat.Add("Steel");
+            MeatOptimization.WhiteListMeat.Add("BlocksSandstone");
         }
     }
 }

--- a/Compatibility/Compatibility_MoolohsDndMenagerie.cs
+++ b/Compatibility/Compatibility_MoolohsDndMenagerie.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+/** Certain animals from Mooloh's DND Menagerie drop non-meat items (namely steel and sandstone). We need to whitelist these not-really-meat-dropping animals
+ * so this mod doesn't think that steel and stone are meat and bork the game trying to reconcile that idea.
+ * */
+namespace AlienMeatTest.Compatibility
+{
+    public class Compatibility_MoolohsDndMenagerie : Compatibility
+    {
+        protected override string PackageID => "mooloh.dndmenagerie";
+        public override bool IsPreOptimization => true;
+        public override void DoPatch()
+        {
+            if (!DetectMod()) return;
+            MeatLogger.Debug("Mooloh's DND Menagerie!");
+
+            MeatOptimization.WhiteListRace.Add("DND_GolemSteel");
+            MeatOptimization.WhiteListRace.Add("DND_GolemStone");
+            MeatOptimization.WhiteListRace.Add("DND_AnimatedToolCabinet"); 
+            MeatOptimization.WhiteListRace.Add("DND_AnimatedDiningChair");
+            MeatOptimization.WhiteListRace.Add("DND_AnimatedStool");
+        }
+    }
+}

--- a/Compatibility/Compatibility_MoolohsDndMenagerie.cs
+++ b/Compatibility/Compatibility_MoolohsDndMenagerie.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-/** Certain animals from Mooloh's DND Menagerie drop non-meat items (namely steel and sandstone). We need to whitelist these not-really-meat-dropping animals
- * so this mod doesn't think that steel and stone are meat and bork the game trying to reconcile that idea.
+/** Certain animals from Mooloh's DND Menagerie drop non-meat items (namely steel and sandstone). We need to whitelist these not-really-meat defs to avoid having the 
+ * optimizer try to remove these defs from the game.
  * */
 namespace AlienMeatTest.Compatibility
 {


### PR DESCRIPTION
My Animal Mod (https://steamcommunity.com/sharedfiles/filedetails/?id=2751849453) includes a few animals which have non-meat defs listed as their meat (specifically steel and sandstone blocks for steel golems, animated tool cabinets, and stone golems). This caused problems when this mod tried to treat such defs like meat during the optimization process. To reconcile this, I added a compatibility patch which whitelists steel and sandstone.

With this patch, there are no longer startup errors related to sandstone not existing, and the aforementioned animals once again turn into a pile of steel or sandstone upon death.

Doesn't include compile changes because I had to severely mess up the project settings to make this build locally.